### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/snowflake_abnormal_usage_of_oauth_access_token.yml
+++ b/rules/snowflake_abnormal_usage_of_oauth_access_token.yml
@@ -22,7 +22,6 @@ description: |-
   1. Inspect the logs to verify if the IP address aligns with expected user or service account behavior.
   2. Investigate unfamiliar IP addresses that are followed by query activity.
   3. If the account is compromised, recreate the access token.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_brute_force_attack_on_user.yml
+++ b/rules/snowflake_brute_force_attack_on_user.yml
@@ -2,7 +2,6 @@
 name: Snowflake Brute Force Attack on User
 description: |-
   Detect a potential brute force attack by monitoring failed logins from the same Snowflake user.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_brute_force_by_ip.yml
+++ b/rules/snowflake_brute_force_by_ip.yml
@@ -2,7 +2,6 @@
 name: Snowflake Brute Force Attacks by IP
 description: |-
   Detect a potential brute force attack by monitoring failed logins from the same IP address.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_discovery_activity.yml
+++ b/rules/snowflake_discovery_activity.yml
@@ -3,7 +3,6 @@ name: Snowflake Discovery Activity
 description: |-
   Detect possible discovery activity in Snowflake by monitoring SHOW queries.
   This can indicate potential reconnaissance or enumeration attempts.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_external_data_share.yml
+++ b/rules/snowflake_external_data_share.yml
@@ -3,7 +3,6 @@ name: Snowflake External Data Share
 description: |-
   Detect when a data transfer between different cloud regions or providers
   occurs, which may indicate data exfiltration or unauthorized data movement.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_file_downloaded_from_stage.yml
+++ b/rules/snowflake_file_downloaded_from_stage.yml
@@ -2,7 +2,6 @@
 name: Snowflake File Downloaded from Stage
 description: |-
   Detect when files are downloaded from Snowflake stages, which may indicate data exfiltration attempts.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_known_malicious_client_application_session.yml
+++ b/rules/snowflake_known_malicious_client_application_session.yml
@@ -3,7 +3,6 @@ name: Snowflake Known Malicious Client Application Session
 description: |-
   Detect known malicious client applications interacting in your Snowflake environment.
   An attacker may set up a session from an outside tool to access and exfiltrate data.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_login_without_mfa.yml
+++ b/rules/snowflake_login_without_mfa.yml
@@ -2,7 +2,6 @@
 name: Snowflake Login Without MFA
 description: |-
   Detect Snowflake logins without multi-factor authentication.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_long_query_process_time.yml
+++ b/rules/snowflake_long_query_process_time.yml
@@ -3,7 +3,6 @@ name: Snowflake Long Query Process Time
 description: |-
   Detect queries with long processing times. This can indicate
   potential denial of service orresource exhaustion attacks.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_multiple_failed_queries.yml
+++ b/rules/snowflake_multiple_failed_queries.yml
@@ -3,7 +3,6 @@ name: Snowflake Multiple Failed Queries
 description: |-
   Detect when multiple failed queries are executed in Snowflake.
   This can indicate potential discovery or enumeration attempts.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_multiple_login_failures_by_ip.yml
+++ b/rules/snowflake_multiple_login_failures_by_ip.yml
@@ -4,7 +4,6 @@ description: |-
   Detect multiple login failures from a single IP in Snowflake.
   This can indicate potential brute force or credential stuffing
   attacks.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_multiple_login_failures_by_user.yml
+++ b/rules/snowflake_multiple_login_failures_by_user.yml
@@ -3,7 +3,6 @@ name: Snowflake Multiple Login Failures by User
 description: |-
   Detect multiple login failures by a user in Snowflake. This can
   indicate potential brute force or credential stuffing attacks.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_network_policy_modified.yml
+++ b/rules/snowflake_network_policy_modified.yml
@@ -15,7 +15,6 @@ description: |-
   2. Investigate if the user is an admin by referencing the Grants to User table in Snowflake.
   3. If the user is not an admin or was recently assigned admin, check for signs of compromise.
   4. Otherwise, review internal change management to verify if this was an expected change.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_possible_data_destruction.yml
+++ b/rules/snowflake_possible_data_destruction.yml
@@ -2,7 +2,6 @@
 name: Snowflake Possible Data Destruction
 description: |-
   Detect possible data destruction in Snowflake via succesful DROP queries.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_privileges_discovery.yml
+++ b/rules/snowflake_privileges_discovery.yml
@@ -4,7 +4,6 @@ description: |-
   Detect possible privileges discovery activity in Snowflake.
   This can indicate potential reconnaissance or privilege
   escalation attempts.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_public_role_granted.yml
+++ b/rules/snowflake_public_role_granted.yml
@@ -2,7 +2,6 @@
 name: Snowflake Public Role Granted
 description: |-
   Detect grants to the public role.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_select_all_query.yml
+++ b/rules/snowflake_select_all_query.yml
@@ -2,7 +2,6 @@
 name: Snowflake Select All Query
 description: |-
   Detect "SELECT *" queries in Snowflake, which may indicate data collection or reconnaissance activities.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_table_copied_into_stage.yml
+++ b/rules/snowflake_table_copied_into_stage.yml
@@ -3,7 +3,6 @@ name: Snowflake Table Copied Into Stage
 description: |
   Detect when data is copied from tables into stages,
   which may indicate data exfiltration attempts.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_temp_stage_created.yml
+++ b/rules/snowflake_temp_stage_created.yml
@@ -3,7 +3,6 @@ name: Snowflake Temporary Stage Created
 description: |-
   Detect when temporary stages are created, which may be
   used for data exfiltration or staging malicious files.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_ui_login_via_password.yml
+++ b/rules/snowflake_ui_login_via_password.yml
@@ -15,7 +15,6 @@ description: |-
   2. Review the IP address against other logs associated with that user.
   3. Investigate whether the user has multi-factor authentication (MFA) enabled.
   4. If the IP address is new and MFA is not enabled, disable the user and rotate credentials.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_user_created.yml
+++ b/rules/snowflake_user_created.yml
@@ -2,7 +2,6 @@
 name: Snowflake User Created
 description: |-
   Detect when new users are created in Snowflake.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_user_enabled.yml
+++ b/rules/snowflake_user_enabled.yml
@@ -2,7 +2,6 @@
 name: Snowflake User Enabled
 description: |-
   Detect when previously disabled user accounts are reenabled in Snowfake.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:snowflake

--- a/rules/snowflake_user_granted_admin_role.yml
+++ b/rules/snowflake_user_granted_admin_role.yml
@@ -14,7 +14,6 @@ description: |-
   1. Inspect the logs to identify the user, role granted, and timestamp.
   2. Investigate whether the user's elevated permissions are expected.
   3. If there are signs of compromise, disable the user associated with the admin grant and rotate credentials.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:snowflake


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.